### PR TITLE
fix overwriting the default show text/html method for CustomShowable

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -45,8 +45,8 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         if: ${{ inputs.run_codecov }}
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: ${{ inputs.run_codecov }}
         with:
-          file: lcov.info
-          token: ${{ secrets.codecov_token }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: JuliaSatcomFramework/PlutoShowHelpers.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoShowHelpers"
 uuid = "61f21f9a-4073-5473-9260-49250f3db370"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -24,8 +24,8 @@ This function defaults to calling [`show`](@ref) with MIME of type `text/plain` 
 """
 function show_outside_pluto(io::IO, x)
     @nospecialize
-    @warn "show_outside_pluto is not overloaded for $(typeof(x)), defaulting to output of show(io, MIME\"text/plain\", x)"
-    show(io, MIME"text/plain"(), x)
+    @warn "show_outside_pluto is not overloaded for $(typeof(x)), defaulting to output of show(io, x)"
+    show(io, x)
 end
 
 # Customize shown names of type

--- a/src/typedef.jl
+++ b/src/typedef.jl
@@ -282,9 +282,7 @@ function Base.show(io::IO, x::DefaultShowOverload)
     print(nio, ")")
 end
 
-function Base.show(io::IO, mime::MIME"text/html", x::DefaultShowOverload)
-    show(io, mime, AsPlutoTree(unwrap(x)))
-end
+show_outside_pluto(io::IO, x::DefaultShowOverload) = show_outside_pluto(io, unwrap(x))
 
 struct Ellipsis <: CustomShowable end
 
@@ -295,3 +293,4 @@ function show_inside_pluto(io::IO, x::Ellipsis)
     <ellipsis></ellipsis>
     """))
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,16 @@ using TestItemRunner
     using Aqua
     Aqua.test_all(PlutoShowHelpers)
 end
+
+@testitem "DualDisplayAngle" begin
+    d = DualDisplayAngle(π/2)
+
+    s = repr(d)
+    @test s === "90° (1.571 rad)"
+
+    @test s === repr(MIME"text/plain"(), d)
+
+    d = DualDisplayAngle(π/2, digits = 2)
+    s = repr(d)
+    @test s === "90° (1.57 rad)"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,3 @@
 using TestItemRunner
 
-@testitem "Aqua" begin
-    using PlutoShowHelpers
-    using Aqua
-    Aqua.test_all(PlutoShowHelpers)
-end
-
-@testitem "DualDisplayAngle" begin
-    d = DualDisplayAngle(π/2)
-
-    s = repr(d)
-    @test s === "90° (1.571 rad)"
-
-    @test s === repr(MIME"text/plain"(), d)
-
-    d = DualDisplayAngle(π/2, digits = 2)
-    s = repr(d)
-    @test s === "90° (1.57 rad)"
-end
+@run_package_tests verbose=true

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -1,0 +1,18 @@
+@testitem "Aqua" begin
+    using PlutoShowHelpers
+    using Aqua
+    Aqua.test_all(PlutoShowHelpers)
+end
+
+@testitem "DualDisplayAngle" begin
+    d = DualDisplayAngle(π/2)
+
+    s = repr(d)
+    @test s === "90° (1.571 rad)"
+
+    @test s === repr(MIME"text/plain"(), d)
+
+    d = DualDisplayAngle(π/2, digits = 2)
+    s = repr(d)
+    @test s === "90° (1.57 rad)"
+end


### PR DESCRIPTION
This small PR changes the default `show_outside_pluto` to use the 2-arg show, and also fixes a bug with the show method for DefaultShowOverload