### PR TITLE
swap NamedTupleTools for ConstructionsBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoShowHelpers"
 uuid = "61f21f9a-4073-5473-9260-49250f3db370"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,11 @@ version = "0.3.0-DEV"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
-NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 
 [compat]
 AbstractPlutoDingetjes = "1.3.2"
+ConstructionBase = "1.5.8"
 HypertextLiteral = "0.9.5"
-NamedTupleTools = "0.14.3"
 julia = "1.10"

--- a/src/PlutoShowHelpers.jl
+++ b/src/PlutoShowHelpers.jl
@@ -1,7 +1,7 @@
 module PlutoShowHelpers
 
 using AbstractPlutoDingetjes: is_inside_pluto, AbstractPlutoDingetjes, Display.published_to_js
-using NamedTupleTools: NamedTupleTools, fieldnames, ntfromstruct
+using ConstructionBase: ConstructionBase, getfields
 using HypertextLiteral: HypertextLiteral, @htl
 
 export is_inside_pluto

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -53,8 +53,8 @@ The 2-arg versions can be used to have a different specialized method for showin
 when called outside or inside of Pluto. They both default to simply calling the 1-arg version.
 
 By default, the 1-arg version just translates the provided object into a
-NamedTuple using `ntfromstruct` from NamedTupleTools.jl.
+NamedTuple using `getfields` from ConstructionBase.jl.
 """
-show_namedtuple(@nospecialize(x)) = ntfromstruct(x)
+show_namedtuple(@nospecialize(x)) = getfields(x)
 show_namedtuple(@nospecialize(x), ::InsidePluto) = show_namedtuple(x)
 show_namedtuple(@nospecialize(x), ::OutsidePluto) = show_namedtuple(x)


### PR DESCRIPTION
This PR swaps the NamedTupleTools package for the ConstructionsBase one as it's anyhow used in the rest of our ecosystem and provides the same functionality we were relying on