### PR TITLE
add convenience macro

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,29 +1,18 @@
 name: TagBot
-
 on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
   issue_comment:
     types:
       - created
   workflow_dispatch:
     inputs:
       lookback:
-        type: number
-        default: 3
-
+        description: "Number of days to look back for tags"
+        default: "3"
 permissions:
-  actions: read
-  checks: read
   contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
-
+  pull-requests: write
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
@@ -32,6 +21,5 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.DOCUMENTER_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          registry: JuliaSatcomFramework/JuliaRegistry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file contains the changelog for the ReferenceViews package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 ## Unreleased
+## [0.3.3] - 05/11/2025
+### Added
+- Added a convenience macro `@default_show_overload` to simplify the overload of the show methods for a given type.
 
 ## [0.3.2] - 07/02/2025
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoShowHelpers"
 uuid = "61f21f9a-4073-5473-9260-49250f3db370"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/src/PlutoShowHelpers.jl
+++ b/src/PlutoShowHelpers.jl
@@ -12,6 +12,7 @@ include("typedef.jl")
 export AsPlutoTree, DefaultShowOverload, HideWhenCompact, HideWhenFull, HideAlways, DualDisplayAngle, DisplayLength, Ellipsis, InsidePluto, OutsidePluto
 
 include("utils.jl")
+export @default_show_overload
 
 include("interface_functions.jl")
 end

--- a/src/typedef.jl
+++ b/src/typedef.jl
@@ -232,6 +232,7 @@ Base.show(io::IO, x::MyType) = show(io, DefaultShowOverload(x))
 Base.show(io::IO, mime::MIME"text/html", x::MyType) = show(io, mime, DefaultShowOverload(x))
 Base.show(io::IO, mime::MIME"text/plain", x::MyType) = show(io, mime, DefaultShowOverload(x))
 ```
+or alternatively, by using the convenience macro [`@default_show_overload`](@ref).
 
 Per-type customization of default show can then be achieved by optionally adding a specific method for the following functions:
 - [`show_namedtuple`](@ref)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -155,3 +155,23 @@ function split_digits_html(val; digits = nothing, sigdigits = nothing, suffix = 
     out = "<pre class='no-block'>$full$rounded</pre>"
     return out
 end
+
+"""
+    @default_show_overload TYPE
+    
+This convenience macro simplifies the overload of the show methods for a given `TYPE` by expanding to the following three method definitions:
+```julia
+Base.show(io::IO, x::TYPE) = show(io, PlutoShowHelpers.DefaultShowOverload(x))
+Base.show(io::IO, mime::MIME"text/html", x::TYPE) = show(io, mime, PlutoShowHelpers.DefaultShowOverload(x))
+Base.show(io::IO, mime::MIME"text/plain", x::TYPE) = show(io, mime, PlutoShowHelpers.DefaultShowOverload(x))
+```
+
+See also: [`DefaultShowOverload`](@ref)
+"""
+macro default_show_overload(TYPE)
+    quote
+        Base.show(io::IO, x::$TYPE) = show(io, $DefaultShowOverload(x))
+        Base.show(io::IO, mime::MIME"text/html", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
+        Base.show(io::IO, mime::MIME"text/plain", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
+    end |> esc
+end

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -199,3 +199,25 @@ end
 end
 
 
+@testitem "DefaultShowOverload Macro" setup = [setup_basics] begin  
+    struct ShowTest
+        a::Int
+        b::String
+        c::Float64
+    end
+
+    struct MAH end
+
+    @default_show_overload Union{ShowTest, MAH}
+
+    @test which(Base.show, (IO, ShowTest)) == which(Base.show, (IO, MAH))
+
+    PlutoShowHelpers.show_namedtuple(::ShowTest, ::OutsidePluto) = (;
+        only = "Override!"
+    )
+
+    st = ShowTest(1, "hello", 1.23)
+    @test contains(repr(st), "Override!")
+    @test contains(repr(MIME"text/html"(), st), "Override!")
+    @test contains(repr(MIME"text/plain"(), st), "Override!")
+end


### PR DESCRIPTION
Add a convenience `@default_show_overload` macro to simplify overloading show for custom types using `DefaultShowOverload`.