### PR TITLE
fix display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This file contains the changelog for the ReferenceViews package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 ## Unreleased
+## [0.3.4] - 05/11/2025
+
+### Fixed
+- Collapse status of PlutoTree objects should now persist at least upon reactive re-run of a cell (not with direct manual rerun)
+
 ## [0.3.3] - 05/11/2025
 ### Added
 - Added a convenience macro `@default_show_overload` to simplify the overload of the show methods for a given type.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoShowHelpers"
 uuid = "61f21f9a-4073-5473-9260-49250f3db370"
 authors = ["Alberto Mengali <a.mengali@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/src/typedef.jl
+++ b/src/typedef.jl
@@ -81,6 +81,7 @@ AsPlutoTree(element; class = nothing, style = nothing) = AsPlutoTree(element, cl
 function show_inside_pluto(io::IO, wrapped::AsPlutoTree)
     item = unwrap(wrapped)
     nt = show_namedtuple(item, InsidePluto())::NamedTuple
+    id = "plutotree_display_id"
     class = @something wrapped.class random_class()
     # This is the style that will eventually hide fields when compact
     default_style = default_plutotree_style(class, nt)
@@ -91,7 +92,7 @@ function show_inside_pluto(io::IO, wrapped::AsPlutoTree)
     mime = MIME"application/vnd.pluto.tree+object"()
     result = @htl("""
     <div class='as-pluto-tree'>
-    <pluto-display class=$(class)></pluto-display><script id=$(random_class())>
+    <pluto-display class=$(class)></pluto-display><script id=$(id)>
         const body = $(published_to_js(body));
         const mime = $(string(mime));
         


### PR DESCRIPTION
- Collapse status of PlutoTree objects should now persist at least upon reactive re-run of a cell (not with direct manual rerun)