### PR TITLE
Render PlutoShowHelpers types as text/plain in Documenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file contains the changelog for the PlutoShowHelpers package. It follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [Unreleased]
+
+### Added
+- `disable_html_show!` — an opt-in call for documentation builds that makes Documenter render types handled by this package with their REPL (`text/plain`) representation instead of their HTML one. Documenter's `@example` blocks pick the richest MIME a value supports and gate that choice on `Base.showable`, so without it they render through `show_outside_pluto` rather than the REPL form. Call it once from `make.jl` before `makedocs`, or from a `@setup` block. Types defined afterwards are covered too, including those registered inside `@example` blocks. Accepts extra types positionally for hand-written `text/html` show methods, and an `exclude` keyword for types that should keep rendering as HTML.
+- `uses_default_html_show` — the trait `disable_html_show!` uses to find those types. Declared for `CustomShowable` and emitted by `@default_show_overload`; it has no effect on how a type is shown.
+
 ## [0.3.6] - 2026-07-10
 
 ### Fixed

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,10 @@ using Documenter
 using DocumenterVitepress
 using PlutoShowHelpers
 
+# Documenter's @example blocks prefer text/html; this makes them fall through to the
+# text/plain rendering these types are designed for.
+PlutoShowHelpers.disable_html_show!()
+
 makedocs(;
     sitename = "PlutoShowHelpers",
     authors = "Alberto Mengali",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,3 +34,10 @@ PlutoShowHelpers.repl_summary
 ```@docs
 @default_show_overload
 ```
+
+## Documenter Integration
+
+```@docs
+PlutoShowHelpers.disable_html_show!
+PlutoShowHelpers.uses_default_html_show
+```

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -36,6 +36,10 @@ struct Orbit
 end
 
 @default_show_overload Orbit
+
+# Orbit is defined here rather than in a loaded package, so it is registered after the
+# disable_html_show! call in make.jl. See "Using These Types in Documenter" below.
+PlutoShowHelpers.disable_html_show!()
 nothing # hide
 ```
 
@@ -48,7 +52,7 @@ Base.show(io::IO, mime::MIME"text/plain", x::Orbit) = show(io, mime, DefaultShow
 
 Without any further customization, all fields are shown using their original names:
 
-```@repl guide
+```@example guide
 orb = Orbit(7000.0, 0.001, 0.9, 1.2, 0.5, 0.0)
 ```
 
@@ -304,6 +308,58 @@ repr(Config(:gpu, 8, false))
 ```
 
 The `backend` field keeps its label in the compact form while `threads` does not.
+
+## Using These Types in Documenter
+
+Documenter's `@example` blocks display a result using the richest MIME type the value
+supports, and ask `Base.showable` which those are. Because `@default_show_overload` and
+[`CustomShowable`](@ref) both define a `text/html` method, `@example` blocks pick HTML —
+which outside Pluto falls back to
+[`show_outside_pluto`](@ref PlutoShowHelpers.show_outside_pluto) and is rarely what you
+want in a manual.
+
+Call [`disable_html_show!`](@ref PlutoShowHelpers.disable_html_show!) once per build to
+make those blocks use the REPL (`text/plain`) rendering instead. Either from `make.jl`,
+before `makedocs`:
+
+```julia
+using MyPackage
+using PlutoShowHelpers
+
+PlutoShowHelpers.disable_html_show!()
+```
+
+or from a `@setup` block in a page:
+
+````markdown
+```@setup tutorial
+using PlutoShowHelpers
+PlutoShowHelpers.disable_html_show!()
+```
+````
+
+It picks up every type registered by [`@default_show_overload`](@ref) and every subtype of
+[`CustomShowable`](@ref). Pass types whose `text/html` show you wrote by hand as positional
+arguments, and types that should keep rendering as HTML via `exclude`:
+
+```julia
+PlutoShowHelpers.disable_html_show!(MyHandWrittenType; exclude = (MyPlotType,))
+```
+
+`@repl` blocks never consult `showable`, so they are already text-only and need none of
+this. The call also leaves `show(io, MIME"text/html"(), x)` and Pluto rendering untouched —
+it changes only which MIME Documenter asks for.
+
+!!! note "Call it after your types are defined"
+    `disable_html_show!` only gives a method to types that exist when it runs. Calling it
+    in `make.jl` after `using MyPackage` covers everything that package defines. A type
+    registered later — such as one defined with [`@default_show_overload`](@ref) inside an
+    `@example` block, as on this page — needs another call after its definition. Subtypes
+    of [`CustomShowable`](@ref) are exempt, because their method is installed on the
+    abstract type and so covers subtypes defined at any point.
+
+This documentation is built with the call in place, so the `@example` blocks throughout
+this guide show the same output you would get in the REPL.
 
 ## Advanced Patterns
 

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -36,10 +36,6 @@ struct Orbit
 end
 
 @default_show_overload Orbit
-
-# Orbit is defined here rather than in a loaded package, so it is registered after the
-# disable_html_show! call in make.jl. See "Using These Types in Documenter" below.
-PlutoShowHelpers.disable_html_show!()
 nothing # hide
 ```
 
@@ -350,13 +346,11 @@ PlutoShowHelpers.disable_html_show!(MyHandWrittenType; exclude = (MyPlotType,))
 this. The call also leaves `show(io, MIME"text/html"(), x)` and Pluto rendering untouched —
 it changes only which MIME Documenter asks for.
 
-!!! note "Call it after your types are defined"
-    `disable_html_show!` only gives a method to types that exist when it runs. Calling it
-    in `make.jl` after `using MyPackage` covers everything that package defines. A type
-    registered later — such as one defined with [`@default_show_overload`](@ref) inside an
-    `@example` block, as on this page — needs another call after its definition. Subtypes
-    of [`CustomShowable`](@ref) are exempt, because their method is installed on the
-    abstract type and so covers subtypes defined at any point.
+One call covers the whole build, including types that do not exist yet when it runs.
+Subtypes of [`CustomShowable`](@ref) are caught because their method sits on the abstract
+type, and [`@default_show_overload`](@ref) checks whether the call has happened and emits
+the `showable` method itself — so a type defined inside an `@example` block, like the
+`Orbit` above, is covered without a second call.
 
 This documentation is built with the call in place, so the `@example` blocks throughout
 this guide show the same output you would get in the REPL.

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -15,11 +15,9 @@ and radians. In compact contexts only degrees are shown.
 using PlutoShowHelpers
 
 a = DualDisplayAngle(π/4)
-nothing # hide
 ```
 
 ```@repl angles
-a
 repr(a)
 ```
 
@@ -48,11 +46,9 @@ to km when the absolute value reaches 1000 m.
 using PlutoShowHelpers
 
 l = DisplayLength(456.789)
-nothing # hide
 ```
 
 ```@repl lengths
-l
 DisplayLength(12345.6)
 DisplayLength(-7500.0; digits=1)
 DisplayLength(NaN)

--- a/src/PlutoShowHelpers.jl
+++ b/src/PlutoShowHelpers.jl
@@ -12,6 +12,8 @@ include("consts.jl")
 include("typedef.jl")
 export AsPlutoTree, DefaultShowOverload, HideWhenCompact, HideWhenFull, HideAlways, DualDisplayAngle, DisplayLength, Ellipsis, InsidePluto, OutsidePluto
 
+include("documenter.jl")
+
 include("utils.jl")
 export @default_show_overload
 

--- a/src/documenter.jl
+++ b/src/documenter.jl
@@ -48,6 +48,12 @@ blocks are text-only to begin with and are unaffected.
 Call it once per documentation build, either from `make.jl` before `makedocs`, or from a
 Documenter `@setup` block. See the guide for worked examples.
 
+Only types that already exist when it runs get a method, so call it after loading the
+packages whose types you are documenting. Types defined later — for instance by a
+[`@default_show_overload`](@ref) inside an `@example` block — need another call afterwards.
+Subtypes of [`CustomShowable`](@ref) are exempt: their method is installed on the abstract
+type and therefore also covers subtypes defined later.
+
 `extra` covers types whose `text/html` show method was written by hand rather than through
 [`@default_show_overload`](@ref) or by subtyping [`CustomShowable`](@ref).
 

--- a/src/documenter.jl
+++ b/src/documenter.jl
@@ -12,6 +12,14 @@ on how a type is shown.
 uses_default_html_show(::Type) = false
 uses_default_html_show(::Type{<:CustomShowable}) = true
 
+# Set by disable_html_show! and read by @default_show_overload at macro-expansion time, so
+# that types defined after that call — such as those defined inside a Documenter @example
+# block — are hidden from text/html rendering as well.
+#
+# Precompilation always runs in a fresh process where this is false, so the conditional
+# method can never be baked into a downstream package's cache.
+const HTML_SHOW_DISABLED = Ref(false)
+
 # Recover `T` from the `::Type{<:T}` (or `::Type{T}`) annotation of a
 # `uses_default_html_show` method. Returns `nothing` for the `::Type` fallback, whose type
 # variable is bounded by `Any`.
@@ -48,11 +56,11 @@ blocks are text-only to begin with and are unaffected.
 Call it once per documentation build, either from `make.jl` before `makedocs`, or from a
 Documenter `@setup` block. See the guide for worked examples.
 
-Only types that already exist when it runs get a method, so call it after loading the
-packages whose types you are documenting. Types defined later — for instance by a
-[`@default_show_overload`](@ref) inside an `@example` block — need another call afterwards.
-Subtypes of [`CustomShowable`](@ref) are exempt: their method is installed on the abstract
-type and therefore also covers subtypes defined later.
+Types defined after the call are covered too: subtypes of [`CustomShowable`](@ref) through
+the method installed on the abstract type, and [`@default_show_overload`](@ref) types
+because the macro checks whether this function has run and emits the `showable` method
+itself. A single call therefore covers a whole build, including types defined inside
+`@example` blocks.
 
 `extra` covers types whose `text/html` show method was written by hand rather than through
 [`@default_show_overload`](@ref) or by subtyping [`CustomShowable`](@ref).
@@ -70,6 +78,7 @@ the same top-level expression that calls it; use `Base.invokelatest` if you need
 Documenter block is evaluated separately, so this does not arise in a docs build.
 """
 function disable_html_show!(extra::Type...; exclude = ())
+    HTML_SHOW_DISABLED[] = true
     excluded = collect(Type, exclude)
     traited = Type[T for T in map(_traited_type, methods(uses_default_html_show)) if T !== nothing]
     types = setdiff(vcat(traited, collect(Type, extra)), excluded)

--- a/src/documenter.jl
+++ b/src/documenter.jl
@@ -1,0 +1,77 @@
+"""
+    uses_default_html_show(::Type) -> Bool
+
+Return `true` for types whose `MIME"text/html"` show method is provided by
+PlutoShowHelpers, either by subtyping [`CustomShowable`](@ref) or through
+[`@default_show_overload`](@ref).
+
+This trait exists so that [`disable_html_show!`](@ref) can find those types by walking
+`methods(uses_default_html_show)`. Nothing else consults it, and declaring it has no effect
+on how a type is shown.
+"""
+uses_default_html_show(::Type) = false
+uses_default_html_show(::Type{<:CustomShowable}) = true
+
+# Recover `T` from the `::Type{<:T}` (or `::Type{T}`) annotation of a
+# `uses_default_html_show` method. Returns `nothing` for the `::Type` fallback, whose type
+# variable is bounded by `Any`.
+function _traited_type(m::Method)
+    T = m.sig.parameters[2]
+    if T isa UnionAll
+        ub = T.var.ub
+        return ub === Any ? nothing : ub
+    elseif T isa DataType && T <: Type && length(T.parameters) == 1
+        p = T.parameters[1]
+        return p isa Type ? p : nothing
+    end
+    return nothing
+end
+
+"""
+    disable_html_show!(extra::Type...; exclude = ()) -> Vector{Type}
+
+Make Documenter render PlutoShowHelpers-driven types with their REPL (`text/plain`)
+representation instead of their HTML one, by defining
+
+```julia
+Base.showable(::MIME"text/html", ::T) = false
+```
+
+for every `T` for which [`uses_default_html_show`](@ref) is `true`, plus any `extra` types
+given. Returns the vector of types that were disabled.
+
+Documenter's `@example` blocks pick the richest available MIME and consult `Base.showable`
+to decide whether `text/html` is available; with this method in place they fall through to
+the `text/plain` output they already generate, rendered as a normal code block. `@repl`
+blocks are text-only to begin with and are unaffected.
+
+Call it once per documentation build, either from `make.jl` before `makedocs`, or from a
+Documenter `@setup` block. See the guide for worked examples.
+
+`extra` covers types whose `text/html` show method was written by hand rather than through
+[`@default_show_overload`](@ref) or by subtyping [`CustomShowable`](@ref).
+
+Types listed in `exclude` keep their HTML rendering. Because the `CustomShowable` method is
+installed on an abstract type, omitting a subtype from the set would not spare it, so each
+excluded type gets an explicit `Base.showable(::MIME"text/html", ::T) = true`, which is more
+specific and therefore wins.
+
+This only changes MIME negotiation. `show(io, MIME"text/html"(), x)` and
+`repr(MIME"text/html"(), x)` still produce HTML, and Pluto rendering is untouched.
+
+Because this defines methods, `showable` must not be queried for the affected types within
+the same top-level expression that calls it; use `Base.invokelatest` if you need to. Each
+Documenter block is evaluated separately, so this does not arise in a docs build.
+"""
+function disable_html_show!(extra::Type...; exclude = ())
+    excluded = collect(Type, exclude)
+    traited = Type[T for T in map(_traited_type, methods(uses_default_html_show)) if T !== nothing]
+    types = setdiff(vcat(traited, collect(Type, extra)), excluded)
+    for T in types
+        @eval Base.showable(::MIME"text/html", ::$T) = false
+    end
+    for T in excluded
+        @eval Base.showable(::MIME"text/html", ::$T) = true
+    end
+    return types
+end

--- a/src/documenter.jl
+++ b/src/documenter.jl
@@ -9,8 +9,8 @@ This trait exists so that [`disable_html_show!`](@ref) can find those types by w
 `methods(uses_default_html_show)`. Nothing else consults it, and declaring it has no effect
 on how a type is shown.
 """
-uses_default_html_show(::Type) = false
-uses_default_html_show(::Type{<:CustomShowable}) = true
+uses_default_html_show(::Type) = return false
+uses_default_html_show(::Type{<:CustomShowable}) = return true
 
 # Set by disable_html_show! and read by @default_show_overload at macro-expansion time, so
 # that types defined after that call — such as those defined inside a Documenter @example
@@ -22,17 +22,14 @@ const HTML_SHOW_DISABLED = Ref(false)
 
 # Recover `T` from the `::Type{<:T}` (or `::Type{T}`) annotation of a
 # `uses_default_html_show` method. Returns `nothing` for the `::Type` fallback, whose type
-# variable is bounded by `Any`.
+# variable is bounded by `Any`, and for any annotation that is not a type.
 function _traited_type(m::Method)
     T = m.sig.parameters[2]
-    if T isa UnionAll
+    if T isa UnionAll # `::Type{<:T}`, and the `::Type` fallback where the bound is `Any`
         ub = T.var.ub
         return ub === Any ? nothing : ub
-    elseif T isa DataType && T <: Type && length(T.parameters) == 1
-        p = T.parameters[1]
-        return p isa Type ? p : nothing
     end
-    return nothing
+    return T isa DataType && T <: Type && length(T.parameters) == 1 ? T.parameters[1] : nothing
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -170,13 +170,27 @@ PlutoShowHelpers.uses_default_html_show(::Type{<:TYPE}) = true
 The last of these registers `TYPE` with [`disable_html_show!`](@ref), and has no effect on
 how `TYPE` is shown.
 
+If [`disable_html_show!`](@ref) has already been called in the current process, the macro
+additionally emits
+
+```julia
+Base.showable(::MIME"text/html", ::TYPE) = false
+```
+
+so that types defined during a documentation build are hidden from `text/html` rendering
+like the ones that existed when that call was made.
+
 See also: [`DefaultShowOverload`](@ref), [`disable_html_show!`](@ref)
 """
 macro default_show_overload(TYPE)
-    quote
+    ex = quote
         Base.show(io::IO, x::$TYPE) = show(io, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/html", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/plain", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
         $(PlutoShowHelpers).uses_default_html_show(::Type{<:$TYPE}) = true
-    end |> esc
+    end
+    if HTML_SHOW_DISABLED[]
+        push!(ex.args, :(Base.showable(::MIME"text/html", ::$TYPE) = false))
+    end
+    return esc(ex)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -187,10 +187,10 @@ macro default_show_overload(TYPE)
         Base.show(io::IO, x::$TYPE) = show(io, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/html", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/plain", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
-        $(PlutoShowHelpers).uses_default_html_show(::Type{<:$TYPE}) = true
+        $(PlutoShowHelpers).uses_default_html_show(::Type{<:$TYPE}) = return true
     end
     if HTML_SHOW_DISABLED[]
-        push!(ex.args, :(Base.showable(::MIME"text/html", ::$TYPE) = false))
+        push!(ex.args, :(Base.showable(::MIME"text/html", ::$TYPE) = return false))
     end
     return esc(ex)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,19 +159,24 @@ end
 """
     @default_show_overload TYPE
     
-This convenience macro simplifies the overload of the show methods for a given `TYPE` by expanding to the following three method definitions:
+This convenience macro simplifies the overload of the show methods for a given `TYPE` by expanding to the following method definitions:
 ```julia
 Base.show(io::IO, x::TYPE) = show(io, PlutoShowHelpers.DefaultShowOverload(x))
 Base.show(io::IO, mime::MIME"text/html", x::TYPE) = show(io, mime, PlutoShowHelpers.DefaultShowOverload(x))
 Base.show(io::IO, mime::MIME"text/plain", x::TYPE) = show(io, mime, PlutoShowHelpers.DefaultShowOverload(x))
+PlutoShowHelpers.uses_default_html_show(::Type{<:TYPE}) = true
 ```
 
-See also: [`DefaultShowOverload`](@ref)
+The last of these registers `TYPE` with [`disable_html_show!`](@ref), and has no effect on
+how `TYPE` is shown.
+
+See also: [`DefaultShowOverload`](@ref), [`disable_html_show!`](@ref)
 """
 macro default_show_overload(TYPE)
     quote
         Base.show(io::IO, x::$TYPE) = show(io, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/html", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
         Base.show(io::IO, mime::MIME"text/plain", x::$TYPE) = show(io, mime, $DefaultShowOverload(x))
+        $(PlutoShowHelpers).uses_default_html_show(::Type{<:$TYPE}) = true
     end |> esc
 end

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -281,3 +281,62 @@ end
     @test contains(repr(MIME"text/html"(), st), "Override!")
     @test contains(repr(MIME"text/plain"(), st), "Override!")
 end
+
+# Tagged :after because disable_html_show! adds Base.showable methods for types owned by
+# neither Base nor PlutoShowHelpers, which the Aqua piracy check flags if it runs later.
+@testitem "disable_html_show!" tags = [:after] begin
+    using PlutoShowHelpers
+    using PlutoShowHelpers: disable_html_show!, uses_default_html_show, CustomShowable
+    using Test
+
+    struct ViaMacro
+        x::Int
+    end
+    @default_show_overload ViaMacro
+
+    struct ViaSubtyping <: CustomShowable
+        x::Int
+    end
+    PlutoShowHelpers.show_outside_pluto(io::IO, v::ViaSubtyping) = print(io, "<b>", v.x, "</b>")
+
+    struct StaysHTML
+        x::Int
+    end
+    @default_show_overload StaysHTML
+
+    struct NoOverload
+        x::Int
+    end
+
+    # The trait is declared by the macro and by CustomShowable, and by nothing else.
+    @test uses_default_html_show(ViaMacro)
+    @test uses_default_html_show(ViaSubtyping)
+    @test !uses_default_html_show(NoOverload)
+
+    m, s, k = ViaMacro(1), ViaSubtyping(2), StaysHTML(3)
+
+    # No pre-state assertion for `s`: the method disabling it is installed on the abstract
+    # CustomShowable, so it survives in a reused test process and catches any later subtype.
+    @test showable(MIME"text/html"(), m)
+    @test showable(MIME"text/html"(), k)
+
+    plain_before = repr(MIME"text/plain"(), m)
+    html_before = repr(MIME"text/html"(), s)
+
+    disabled = disable_html_show!(; exclude = (StaysHTML,))
+
+    @test ViaMacro in disabled
+    @test CustomShowable in disabled
+    @test StaysHTML ∉ disabled
+
+    # ViaMacro is disabled by its own method, ViaSubtyping by the abstract CustomShowable
+    # method alone, StaysHTML kept by an explicit `= true`.
+    @test !invokelatest(showable, MIME"text/html"(), m)
+    @test !invokelatest(showable, MIME"text/html"(), s)
+    @test invokelatest(showable, MIME"text/html"(), k)
+
+    # Only MIME negotiation changes; rendering is untouched. `repr` calls `show` directly
+    # and never consults `showable`, so HTML is still produced on demand.
+    @test invokelatest(repr, MIME"text/plain"(), m) == plain_before
+    @test invokelatest(repr, MIME"text/html"(), s) == html_before == "<b>2</b>"
+end

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -286,32 +286,55 @@ end
 # neither Base nor PlutoShowHelpers, which the Aqua piracy check flags if it runs later.
 @testitem "disable_html_show!" tags = [:after] begin
     using PlutoShowHelpers
-    using PlutoShowHelpers: disable_html_show!, uses_default_html_show, CustomShowable
+    using PlutoShowHelpers: disable_html_show!, uses_default_html_show, CustomShowable, HTML_SHOW_DISABLED
     using Test
 
-    struct ViaMacro
-        x::Int
-    end
-    @default_show_overload ViaMacro
+    # A reused worker still carries HTML_SHOW_DISABLED from an earlier run of this item, and
+    # `Core.eval` expands every macro in a block before running any of it. The definitions
+    # below are therefore @eval'd so they expand after this reset rather than before it.
+    HTML_SHOW_DISABLED[] = false
 
-    struct ViaSubtyping <: CustomShowable
-        x::Int
-    end
-    PlutoShowHelpers.show_outside_pluto(io::IO, v::ViaSubtyping) = print(io, "<b>", v.x, "</b>")
+    @eval begin
+        struct ViaMacro
+            x::Int
+        end
+        @default_show_overload ViaMacro
 
-    struct StaysHTML
-        x::Int
-    end
-    @default_show_overload StaysHTML
+        struct ViaSubtyping <: CustomShowable
+            x::Int
+        end
+        PlutoShowHelpers.show_outside_pluto(io::IO, v::ViaSubtyping) = print(io, "<b>", v.x, "</b>")
 
-    struct NoOverload
-        x::Int
+        struct StaysHTML
+            x::Int
+        end
+        @default_show_overload StaysHTML
+
+        # A Union rather than a concrete type or an abstract supertype.
+        struct UnionA end
+        struct UnionB end
+        @default_show_overload Union{UnionA, UnionB}
+
+        # The trait declared invariantly by hand, over a type whose text/html show method
+        # was also written by hand rather than produced by the macro.
+        struct Invariant end
+        Base.show(io::IO, ::MIME"text/html", ::Invariant) = print(io, "<i></i>")
+        PlutoShowHelpers.uses_default_html_show(::Type{Invariant}) = true
+
+        struct NoOverload
+            x::Int
+        end
     end
 
-    # The trait is declared by the macro and by CustomShowable, and by nothing else.
+    # The trait is declared by the macro, by CustomShowable, and by the hand-written method.
     @test uses_default_html_show(ViaMacro)
     @test uses_default_html_show(ViaSubtyping)
+    @test uses_default_html_show(Invariant)
     @test !uses_default_html_show(NoOverload)
+
+    # A Union registration covers each of its members.
+    @test uses_default_html_show(UnionA)
+    @test uses_default_html_show(UnionB)
 
     m, s, k = ViaMacro(1), ViaSubtyping(2), StaysHTML(3)
 
@@ -319,6 +342,9 @@ end
     # CustomShowable, so it survives in a reused test process and catches any later subtype.
     @test showable(MIME"text/html"(), m)
     @test showable(MIME"text/html"(), k)
+    @test showable(MIME"text/html"(), Invariant())
+    @test showable(MIME"text/html"(), UnionA())
+    @test showable(MIME"text/html"(), UnionB())
 
     plain_before = repr(MIME"text/plain"(), m)
     html_before = repr(MIME"text/html"(), s)
@@ -327,7 +353,14 @@ end
 
     @test ViaMacro in disabled
     @test CustomShowable in disabled
+    @test Invariant in disabled
+    @test Union{UnionA, UnionB} in disabled
     @test StaysHTML ∉ disabled
+
+    # A Union is disabled by a single method covering both members.
+    @test !invokelatest(showable, MIME"text/html"(), UnionA())
+    @test !invokelatest(showable, MIME"text/html"(), UnionB())
+    @test !invokelatest(showable, MIME"text/html"(), Invariant())
 
     # ViaMacro is disabled by its own method, ViaSubtyping by the abstract CustomShowable
     # method alone, StaysHTML kept by an explicit `= true`.

--- a/test/testitems.jl
+++ b/test/testitems.jl
@@ -339,4 +339,14 @@ end
     # and never consults `showable`, so HTML is still produced on demand.
     @test invokelatest(repr, MIME"text/plain"(), m) == plain_before
     @test invokelatest(repr, MIME"text/html"(), s) == html_before == "<b>2</b>"
+
+    # A type registered after the call is covered too: the macro sees the flag at expansion
+    # time. @eval defers that expansion past the disable_html_show! call above, which the
+    # surrounding testitem body has already been expanded before running.
+    @eval struct DefinedAfter
+        x::Int
+    end
+    @eval @default_show_overload DefinedAfter
+    @test !invokelatest(showable, MIME"text/html"(), invokelatest(DefinedAfter, 4))
+    @test contains(invokelatest(repr, MIME"text/plain"(), invokelatest(DefinedAfter, 4)), "x = 4")
 end


### PR DESCRIPTION

## Problem

A package that overloads `show` through this package — via `@default_show_overload` or by
subtyping `CustomShowable` — gets the wrong output in its own documentation.

Documenter's `@example` blocks display a result using the richest MIME the value supports,
asking `Base.showable` which those are (`Documenter/src/utilities/utilities.jl:574-586`).
Both entry points define a `text/html` method, so `@example` picks HTML, the IO is not
inside Pluto, and rendering falls through to `show_outside_pluto` — which by default warns
and emits the compact 2-arg form. What you almost always want in a manual is the REPL
(`text/plain`) rendering.

`@repl` blocks were never affected: they go through `result_to_string`
(`expander_pipeline.jl:986`), which is text-only and never consults `showable`.

## Approach

`showable` is Documenter's only gate, so an opt-in helper defines

```julia
Base.showable(::MIME"text/html", ::T) = false
```

for the relevant types. Documenter then never asks for HTML and falls through to the
`text/plain` entry it already generates, rendered as a native code block.

```julia
# docs/make.jl
using MyPackage
using PlutoShowHelpers

PlutoShowHelpers.disable_html_show!()
```

or from a `@setup` block in a single page. Nothing changes on load — without the call the
package behaves exactly as before.

Types are found through a new non-exported trait, `uses_default_html_show`, declared for
`CustomShowable` and emitted by `@default_show_overload`. The trait is inert: nothing in
normal operation consults it, and it is a method rather than a mutated global so it
survives precompilation of the downstream package.

Coverage is complete from a single call:

| Type registered… | Covered by |
|---|---|
| before the call, any kind | trait enumeration — one `showable` method each |
| after the call, `CustomShowable` subtype | the method installed on the abstract type |
| after the call, via `@default_show_overload` | the macro reads a flag at expansion time and emits the method itself |

The last row is what makes types defined inside `@example` blocks work. The flag is only
ever true in a live docs-build process; precompilation runs in a fresh subprocess where it
is false, so the conditional `showable` method can never be baked into a downstream
package's cache.

`extra` positional arguments cover types whose `text/html` show was written by hand.
`exclude` keeps chosen types rendering as HTML — those get an explicit
`showable(...) = true`, which is more specific than the `CustomShowable` method and
therefore wins.

## What this does not do

It changes only MIME negotiation. `show(io, MIME"text/html"(), x)` and
`repr(MIME"text/html"(), x)` still produce HTML, and Pluto rendering is untouched. No
methods are deleted and no dependency is added.

## Alternatives considered

- **A global toggle consulted by this package's own show methods.** Would need either a
  `showable` method emitted unconditionally into every downstream package, or emitting
  `<pre>` from `show_outside_pluto` — raw HTML injected into the page rather than a
  Documenter code fence.
- **`Base.delete_method` on the HTML show methods.** The generic `showable` fallback is
  `hasmethod(show, Tuple{IO,MIME,typeof(x)})`, so deletion reaches the same place by a
  harsher route: process-wide invalidation, not reversible in-session, and it breaks direct
  `show(io, MIME"text/html"(), x)` calls.
- **Auto-detecting Documenter** via loaded modules or an environment variable.
  Unnecessary once the switch is one line in `make.jl`, and surprising in a REPL that
  happens to have Documenter loaded.

## Changes

- `src/documenter.jl` (new) — `uses_default_html_show`, `disable_html_show!`.
- `src/utils.jl` — `@default_show_overload` registers the trait, and emits `showable` when
  `disable_html_show!` has already run.
- `test/testitems.jl` — one testitem, tagged `:after` so it runs after Aqua's piracy check.
- Docs — new "Using These Types in Documenter" guide section, API entries, and the call
  wired into this package's own `make.jl`.

## Dogfooding

This package's docs now build with the call in place. The `@example` blocks that display a
value previously had to suppress their result with `nothing # hide` because the HTML path
mangled it; they now show the value directly. Verified in the built output: `DisplayLength`
renders as `456.789 m`, `Orbit` as its full field listing, no `show_outside_pluto` warnings
in the build log, and no raw package HTML left in any generated page.

## Testing

12/12 testitems pass. Note that `test/runtests.jl` runs `:after`-tagged items in a second
pass — required here, since `disable_html_show!` installs `Base.showable` methods for types
owned by neither `Base` nor this package, which Aqua's piracy check would flag if it ran
afterwards.
